### PR TITLE
Update filter: remove dylanaraps - community

### DIFF
--- a/filter
+++ b/filter
@@ -19,3 +19,4 @@ https://github.com/jleightcap/kiss-ppc
 https://github.com/wyvertux/wyverkiss
 https://github.com/wyvertux/wyvertux
 https://github.com/xuxiaodong/kiss-raspi
+https://github.com/dylanaraps/community


### PR DESCRIPTION
This original community repo, besides it is archived and in consequence does not receive any updates, it is serving the same packages as the one from `kiss-community` and therefore creates noise without any use.