### PR TITLE
build_database.sh: fix for symlinked build files

### DIFF
--- a/src/db/build_database.sh
+++ b/src/db/build_database.sh
@@ -10,7 +10,7 @@ get_path_in_repo() {
 }
 
 find_packages() {
-    find "$1" -name build -type f -exec dirname {} \;
+    find -L "$1" -name build -type f -exec dirname {} \;
 }
 
 fetch_repo() {


### PR DESCRIPTION
Without the -L flag, packages that share a build file via symlink aren't
discovered.

See
  - https://github.com/ehawkvu/kiss-tex/tree/master/texlive/texmeta
  - https://github.com/ehawkvu/kiss-xorg/tree/master/xorg/libXmeta